### PR TITLE
Fix HTML header subtitle closing tag

### DIFF
--- a/layouts/partials/pageContent/header.html
+++ b/layouts/partials/pageContent/header.html
@@ -1,4 +1,4 @@
 <h1 class="mb-0">{{.Title}}</h1>
 {{ with .Params.subtitle }}
-<h2 class="mt-4 font-normal text-xl">{{.}}</span>
+<h2 class="mt-4 font-normal text-xl">{{.}}</h2>
 {{ end }}


### PR DESCRIPTION
## Summary
- fix mismatched closing tag in `header.html`

## Testing
- `python -m pytest -q` *(fails: httpx.ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68704730d320832d8ff638367a7a874e